### PR TITLE
Add a Prompt Maker.

### DIFF
--- a/Prompt_Maker.ps1
+++ b/Prompt_Maker.ps1
@@ -31,3 +31,4 @@ foreach ($element in $prompt){
 }
 
 cmd.exe /c setx PROMPT ($parsed_prompt -Join '$_')
+Write-Output 'Please restart any Command Prompt Sessions!'

--- a/Prompt_Maker.ps1
+++ b/Prompt_Maker.ps1
@@ -1,0 +1,33 @@
+$chars = [ordered]@{
+    '&'  = '$A';
+    '|'  = '$B';
+    '('  = '$C';
+    ')'  = '$F';
+    '>'  = '$G';
+    '<'  = '$L';
+    '='  = '$Q';
+    ' '  = '$S';
+    '\n' = '$_';
+    '\$' = '$$'
+}
+Write-Output '
+$D   Current date
+$E   Escape code
+$N   Current drive
+$P   Current drive and path
+$T   Current time
+$V   Windows version number
+\$   $ (Dollar Sign)
+Enter Prompt, enter a blank line to complete the prompt.
+'
+$parsed_prompt = @()
+$prompt = while (1) { read-host | Set-Variable r; if (!$r) {break}; $r}
+
+foreach ($element in $prompt){
+    foreach ($item in $chars.Keys){
+        $element = $element.replace($item, $chars."$item")
+    }
+    $parsed_prompt += $element
+}
+
+cmd.exe /c setx PROMPT ($parsed_prompt -Join '$_')


### PR DESCRIPTION
This powershell script makes it easier for users to make their own prompts.

![image](https://user-images.githubusercontent.com/41850963/174252872-7161dd62-368b-4657-aae3-ca3b593c26a0.png)
![image](https://user-images.githubusercontent.com/41850963/174253010-05d0a676-4e06-4ded-84eb-81f9808cbb17.png)

How does it work?
Basically the script receives multi-line input from the user and accordingly parses it       
and adds a new Environment variable called `PROMPT` which cmd.exe uses for its prompt.

![image](https://user-images.githubusercontent.com/41850963/174253229-f0eb4cfe-7721-44a3-9755-5dc9d37c4616.png)
